### PR TITLE
Fix: Set proper Content-Type header for non-streaming responses

### DIFF
--- a/internal/proxy/client.go
+++ b/internal/proxy/client.go
@@ -115,6 +115,9 @@ func (c *APIClient) setupResponseHeaders(w http.ResponseWriter, resp *http.Respo
 		w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-cache")
 		w.Header().Set("Connection", "keep-alive")
+	} else {
+		// For non-streaming responses, set proper JSON content type
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	}
 
 	// Set X-Request-ID header


### PR DESCRIPTION
## Fix: Set proper Content-Type header for non-streaming responses

### Problem
Production API was returning garbled/binary-looking responses for OpenAI tool calling requests with `tool_choice='required'`. The response body appeared corrupted with weird characters in the browser/client.

### Root Cause
The proxy was setting `Content-Type: text/plain; charset=utf-8` for all non-streaming responses instead of `Content-Type: application/json; charset=utf-8`. This caused clients to misinterpret JSON responses as plain text, leading to rendering issues.

### Solution
Updated the `setupResponseHeaders` function in `internal/proxy/client.go` to properly set Content-Type headers:
- **Streaming responses**: `text/event-stream; charset=utf-8` (unchanged)
- **Non-streaming responses**: `application/json; charset=utf-8` (fixed)

### Changes
- Added an `else` block in `setupResponseHeaders` to explicitly set the JSON content type for non-streaming responses

### Testing
Verified the fix works correctly for:
- ✅ Non-streaming OpenAI requests
- ✅ Non-streaming Gemini requests  
- ✅ Streaming requests (both vendors)
- ✅ Tool calling requests with `tool_choice: "required"`
- ✅ All existing Go tests pass

### Review
The fix has been reviewed by Codex, which confirmed:
- The approach is correct and necessary
- The implementation is straightforward and clear
- The fix effectively addresses the production issue

### Impact
- Minimal code change (4 lines added)
- No breaking changes
- Fixes critical production issue affecting OpenAI tool calling responses 