### PR TITLE
fix: deployment artifact creation in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,7 @@ jobs:
           --exclude='node_modules' \
           --exclude='*.log' \
           --exclude='coverage.*' \
+          --exclude='deployment-artifact.tar.gz' \
           .
           
     - name: Upload deployment artifact


### PR DESCRIPTION
# Fix Deployment Artifact Creation in CI

## Summary
This PR fixes the deployment artifact creation failure in the CI pipeline that occurs when pushing to the main branch.

## Problem
The `tar` command was failing with the error:
```
tar: .: file changed as we read it
```

This happened because `tar` was trying to include the output file (`deployment-artifact.tar.gz`) in the archive while simultaneously writing to it, causing a race condition.

## Solution
Added `--exclude='deployment-artifact.tar.gz'` to the tar command to exclude the output file from being included in the archive.

## Testing
- The fix has been tested locally
- This will be validated when the PR CI runs

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue) 