### PR TITLE
Add image description endpoint

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -427,6 +427,28 @@ POST /v1/chat/completions?vendor=gemini
 
 Available vendors depend on server configuration.
 
+### Image Description
+
+Generate a detailed textual description of a single image.
+
+#### Request
+```http
+POST /v1/images/text
+Content-Type: application/json
+Authorization: Bearer YOUR_API_KEY
+
+{
+  "type": "image_url",
+  "image_url": {
+    "url": "https://example.com/image.jpg"
+  }
+}
+```
+
+#### Response
+
+Returns the same structure as the chat completions endpoint.
+
 ### Tool Calling
 
 The service supports OpenAI-compatible tool calling:

--- a/docs/api/docs.go
+++ b/docs/api/docs.go
@@ -110,6 +110,63 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/images/text": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Generates a detailed text description of a single image",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "images"
+                ],
+                "summary": "Describe image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Optional vendor to target (e.g., 'openai', 'gemini')",
+                        "name": "vendor",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Image description request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OpenAI-compatible chat completion response",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ChatCompletionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/models": {
             "get": {
                 "description": "Returns a list of available language models in OpenAI-compatible format",
@@ -230,6 +287,32 @@ const docTemplate = `{
             "properties": {
                 "error": {
                     "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorInfo"
+                }
+            }
+        },
+        "github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest": {
+            "type": "object",
+            "properties": {
+                "image_url": {
+                    "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "image_url"
+                }
+            }
+        },
+        "github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders": {
+            "type": "object",
+            "properties": {
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/api/swagger.json
+++ b/docs/api/swagger.json
@@ -104,6 +104,63 @@
                 }
             }
         },
+        "/v1/images/text": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Generates a detailed text description of a single image",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "images"
+                ],
+                "summary": "Describe image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Optional vendor to target (e.g., 'openai', 'gemini')",
+                        "name": "vendor",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Image description request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OpenAI-compatible chat completion response",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ChatCompletionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/models": {
             "get": {
                 "description": "Returns a list of available language models in OpenAI-compatible format",
@@ -224,6 +281,32 @@
             "properties": {
                 "error": {
                     "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorInfo"
+                }
+            }
+        },
+        "github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest": {
+            "type": "object",
+            "properties": {
+                "image_url": {
+                    "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "image_url"
+                }
+            }
+        },
+        "github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders": {
+            "type": "object",
+            "properties": {
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -63,6 +63,23 @@ definitions:
       error:
         $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorInfo'
     type: object
+  github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest:
+    properties:
+      image_url:
+        $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders'
+      type:
+        example: image_url
+        type: string
+    type: object
+  github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders:
+    properties:
+      headers:
+        additionalProperties:
+          type: string
+        type: object
+      url:
+        type: string
+    type: object
   github_com_aashari_go-generative-api-router_internal_types.Message:
     properties:
       content:
@@ -238,6 +255,42 @@ paths:
       summary: Chat completions API
       tags:
       - chat
+  /v1/images/text:
+    post:
+      consumes:
+      - application/json
+      description: Generates a detailed text description of a single image
+      parameters:
+      - description: Optional vendor to target (e.g., 'openai', 'gemini')
+        in: query
+        name: vendor
+        type: string
+      - description: Image description request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OpenAI-compatible chat completion response
+          schema:
+            $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ChatCompletionResponse'
+        "400":
+          description: Bad request error
+          schema:
+            $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Describe image
+      tags:
+      - images
   /v1/models:
     get:
       consumes:

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -104,6 +104,63 @@
                 }
             }
         },
+        "/v1/images/text": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Generates a detailed text description of a single image",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "images"
+                ],
+                "summary": "Describe image",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Optional vendor to target (e.g., 'openai', 'gemini')",
+                        "name": "vendor",
+                        "in": "query"
+                    },
+                    {
+                        "description": "Image description request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OpenAI-compatible chat completion response",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ChatCompletionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal server error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/models": {
             "get": {
                 "description": "Returns a list of available language models in OpenAI-compatible format",
@@ -224,6 +281,32 @@
             "properties": {
                 "error": {
                     "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorInfo"
+                }
+            }
+        },
+        "github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest": {
+            "type": "object",
+            "properties": {
+                "image_url": {
+                    "$ref": "#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders"
+                },
+                "type": {
+                    "type": "string",
+                    "example": "image_url"
+                }
+            }
+        },
+        "github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders": {
+            "type": "object",
+            "properties": {
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "url": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -63,6 +63,23 @@ definitions:
       error:
         $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorInfo'
     type: object
+  github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest:
+    properties:
+      image_url:
+        $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders'
+      type:
+        example: image_url
+        type: string
+    type: object
+  github_com_aashari_go-generative-api-router_internal_types.ImageURLWithHeaders:
+    properties:
+      headers:
+        additionalProperties:
+          type: string
+        type: object
+      url:
+        type: string
+    type: object
   github_com_aashari_go-generative-api-router_internal_types.Message:
     properties:
       content:
@@ -238,6 +255,42 @@ paths:
       summary: Chat completions API
       tags:
       - chat
+  /v1/images/text:
+    post:
+      consumes:
+      - application/json
+      description: Generates a detailed text description of a single image
+      parameters:
+      - description: Optional vendor to target (e.g., 'openai', 'gemini')
+        in: query
+        name: vendor
+        type: string
+      - description: Image description request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ImageToTextRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OpenAI-compatible chat completion response
+          schema:
+            $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ChatCompletionResponse'
+        "400":
+          description: Bad request error
+          schema:
+            $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse'
+        "500":
+          description: Internal server error
+          schema:
+            $ref: '#/definitions/github_com_aashari_go-generative-api-router_internal_types.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Describe image
+      tags:
+      - images
   /v1/models:
     get:
       consumes:

--- a/internal/handlers/api_handlers.go
+++ b/internal/handlers/api_handlers.go
@@ -374,11 +374,11 @@ func (h *APIHandlers) ImageToTextHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	payload := map[string]interface{}{
-		"model": "auto-image-model",
+		"model": utils.DefaultImageModel,
 		"messages": []interface{}{
 			map[string]interface{}{
 				"role":    "system",
-				"content": "Describe the image as detailed as possible. If the image contains text, reproduce it in your response.",
+				"content": utils.ImageDescriptionPrompt,
 			},
 			map[string]interface{}{
 				"role":    "user",

--- a/internal/handlers/api_handlers.go
+++ b/internal/handlers/api_handlers.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"time"
@@ -324,4 +326,92 @@ func (h *APIHandlers) ModelsHandler(w http.ResponseWriter, r *http.Request) {
 			"response_size", len(jsonResp),
 		)
 	}
+}
+
+// ImageToTextHandler handles the image description endpoint
+// @Summary      Describe image
+// @Description  Generates a detailed text description of a single image
+// @Tags         images
+// @Accept       json
+// @Produce      json
+// @Param        vendor  query     string                     false  "Optional vendor to target (e.g., 'openai', 'gemini')"
+// @Param        request body      types.ImageToTextRequest   true   "Image description request"
+// @Security     BearerAuth
+// @Success      200  {object}  types.ChatCompletionResponse "OpenAI-compatible chat completion response"
+// @Failure      400  {object}  types.ErrorResponse          "Bad request error"
+// @Failure      500  {object}  types.ErrorResponse          "Internal server error"
+// @Router       /v1/images/text [post]
+func (h *APIHandlers) ImageToTextHandler(w http.ResponseWriter, r *http.Request) {
+	ctx := logger.WithComponent(r.Context(), "ImageToTextHandler")
+	ctx = logger.WithStage(ctx, "Request")
+
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var imgReq types.ImageToTextRequest
+	if err := json.NewDecoder(r.Body).Decode(&imgReq); err != nil {
+		logger.Error(ctx, "Failed to decode request", err)
+		validationErr := errors.NewValidationError("invalid request format")
+		errors.HandleError(w, validationErr, http.StatusBadRequest)
+		return
+	}
+
+	if imgReq.Type != "image_url" || imgReq.ImageURL.URL == "" {
+		validationErr := errors.NewValidationError("invalid image_url object")
+		errors.HandleError(w, validationErr, http.StatusBadRequest)
+		return
+	}
+
+	// Build chat completion payload with system instruction
+	userContent := map[string]interface{}{
+		"type":      "image_url",
+		"image_url": map[string]interface{}{"url": imgReq.ImageURL.URL},
+	}
+	if len(imgReq.ImageURL.Headers) > 0 {
+		userContent["image_url"].(map[string]interface{})["headers"] = imgReq.ImageURL.Headers
+	}
+
+	payload := map[string]interface{}{
+		"model": "auto-image-model",
+		"messages": []interface{}{
+			map[string]interface{}{
+				"role":    "system",
+				"content": "Describe the image as detailed as possible. If the image contains text, reproduce it in your response.",
+			},
+			map[string]interface{}{
+				"role":    "user",
+				"content": []interface{}{userContent},
+			},
+		},
+	}
+
+	bodyBytes, err := json.Marshal(payload)
+	if err != nil {
+		logger.Error(ctx, "Failed to marshal payload", err)
+		apiErr := errors.NewInternalError("failed to build request")
+		errors.HandleError(w, apiErr, http.StatusInternalServerError)
+		return
+	}
+
+	newReq := r.Clone(r.Context())
+	newReq.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	newReq.ContentLength = int64(len(bodyBytes))
+
+	vendorFilter := r.URL.Query().Get("vendor")
+	creds := h.Credentials
+	models := h.VendorModels
+	if vendorFilter != "" {
+		creds = filter.CredentialsByVendor(creds, vendorFilter)
+		models = filter.ModelsByVendor(models, vendorFilter)
+
+		if len(creds) == 0 || len(models) == 0 {
+			validationErr := errors.NewValidationError("no credentials or models for vendor")
+			errors.HandleError(w, validationErr, http.StatusBadRequest)
+			return
+		}
+	}
+
+	proxy.ProxyRequest(w, newReq, creds, models, h.APIClient, h.ModelSelector)
 }

--- a/internal/router/routes.go
+++ b/internal/router/routes.go
@@ -17,6 +17,7 @@ func SetupRoutes(apiHandlers *handlers.APIHandlers) http.Handler {
 	mux.HandleFunc("/health", apiHandlers.HealthHandler)
 	mux.HandleFunc("/v1/chat/completions", apiHandlers.ChatCompletionsHandler)
 	mux.HandleFunc("/v1/models", apiHandlers.ModelsHandler)
+	mux.HandleFunc("/v1/images/text", apiHandlers.ImageToTextHandler)
 
 	// Add pprof endpoints for performance profiling
 	monitoring.SetupPprofRoutes(mux)

--- a/internal/types/api_models.go
+++ b/internal/types/api_models.go
@@ -116,3 +116,15 @@ type Model struct {
 	Created int64  `json:"created" example:"1677610602"`
 	OwnedBy string `json:"owned_by" example:"openai"`
 }
+
+// ImageToTextRequest represents a request to describe a single image
+type ImageToTextRequest struct {
+	Type     string              `json:"type" example:"image_url"`
+	ImageURL ImageURLWithHeaders `json:"image_url"`
+}
+
+// ImageURLWithHeaders represents an image URL with optional headers
+type ImageURLWithHeaders struct {
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
+}

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -105,6 +105,12 @@ const (
 	AcceptEncodingGzip = "gzip"
 )
 
+// System prompt for describing images
+const ImageDescriptionPrompt = "Describe the image as detailed as possible. If the image contains text, reproduce it in your response."
+
+// Default model name for image description
+const DefaultImageModel = "auto-image-model"
+
 // Header Values for Buffering
 const (
 	XAccelBufferingNo = "no"

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -79,7 +79,7 @@ func TestValidateAndModifyRequest(t *testing.T) {
 							map[string]interface{}{
 								"type": "image_url",
 								"image_url": map[string]interface{}{
-									"url": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==",
+									"url": "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
 								},
 							},
 						},


### PR DESCRIPTION
## Summary
- implement `ImageToTextHandler` to generate text from a single image
- define `ImageToTextRequest` type
- register `/v1/images/text` route
- document new endpoint and regenerate Swagger docs

## Testing
- `go vet ./...`
- `go test ./...`
- `make swagger-generate`

------
https://chatgpt.com/codex/tasks/task_e_684edda5d864832ab1d0dcfa25fee88d